### PR TITLE
Added .gitattributes to fix Linux development compatibility

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto eol=lf
+*.{cmd,[cC][mM][dD]} text eol=crlf
+*.{bat,[bB][aA][tT]} text eol=crlf


### PR DESCRIPTION
.gitattributes was added to prevent Git on Linux seeing that all the files were modified when they aren't.